### PR TITLE
fix: pipeline set-up

### DIFF
--- a/.github/workflows/pytest-and-format.yml
+++ b/.github/workflows/pytest-and-format.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   run-unit-tests:
     name: Run unit tests with pytest
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@master


### PR DESCRIPTION
In order to avoid issues with the pipeline, the desired Python version should be at least 3.8